### PR TITLE
Change from <a href='d3js.org'> to <a href='http://d3js.org'>

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -290,7 +290,7 @@
         <h3>About</h3>
         <p><a href='http://blog.hatnote.com/post/56856315107/listen-to-wikipedia'>Read more</a> about this project.</p>
         <p>Listen to Wikipedia's recent changes feed. The sounds indicate addition to (bells) or subtraction from (strings) a Wikipedia articles, and the pitch changes according to the size of the edit. Green circles show edits from <a href='http://en.wikipedia.org/wiki/Wikipedia:User_access_levels#Unregistered_users'>unregistered contributors</a>, and purple circles mark edits performed by <a href='http://en.wikipedia.org/wiki/Wikipedia:Bots'>automated bots</a>. You may see announcements for new users as they join the site -- you can welcome him or her by adding a note on their talk page.</p>
-        <p>This project is built using <a href='d3js.org'>D3</a> and <a href='https://github.com/goldfire/howler.js'>HowlerJS</a>. It is based on <a href='http://www.listentobitcoin.com/'>Listen to Bitcoin</a> by <a href='https://github.com/MaxLaumeister'>Maximillian Laumeister</a>. Our source is <a href='https://github.com/hatnote/listen-to-wikipedia'>available on GitHub</a>, and you can read more about this project.</p>
+        <p>This project is built using <a href='http://d3js.org'>D3</a> and <a href='https://github.com/goldfire/howler.js'>HowlerJS</a>. It is based on <a href='http://www.listentobitcoin.com/'>Listen to Bitcoin</a> by <a href='https://github.com/MaxLaumeister'>Maximillian Laumeister</a>. Our source is <a href='https://github.com/hatnote/listen-to-wikipedia'>available on GitHub</a>, and you can read more about this project.</p>
         <p>Built by <a href='http://github.com/slaporte'>Stephen LaPorte</a> and <a href='http://github.com/mahmoud'>Mahmoud Hashemi</a>.
     </div>
     <script>


### PR DESCRIPTION
Change from `<a href='d3js.org'>` to `<a href='http://d3js.org'>` so the link will go to `http://d3js.org`, not `http://listen.hatnote.com/d3js.org`
