### PR TITLE
Update Listen to Bitcoin to Bitlisten

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Listen to Wikipedia is inspired by Maximillian Laumeister's [Listen to Bitcoin](http://www.listentobitcoin.com/). 
+Listen to Wikipedia is inspired by Maximillian Laumeister's [Listen to Bitcoin](http://www.bitlisten.com/). 
 
 ## About
 


### PR DESCRIPTION
Maximillian changed the domain to bitlisten.com some time ago. The current link here is dead. I noticed the site was on reddit recently, so I thought this should correctly point to his current active site.