### PR TITLE
Replace "Farsi" with "Persian"

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -95,7 +95,7 @@
         'it': ['Italian', 'ws://wikimon.hatnote.com:9070'],
         'sv': ['Swedish', 'ws://wikimon.hatnote.com:9080'],
         'ar': ['Arabic', 'ws://wikimon.hatnote.com:9090'],
-        'fa': ['Farsi', 'ws://wikimon.hatnote.com:9210'],
+        'fa': ['Persian', 'ws://wikimon.hatnote.com:9210'],
         'he': ['Hebrew' , 'ws://wikimon.hatnote.com:9230'],
         'id': ['Indonesian', 'ws://wikimon.hatnote.com:9100'],
         'zh': ['Chinese', 'ws://wikimon.hatnote.com:9240'],


### PR DESCRIPTION
Persian is more appropiate name for the language, https://en.wikipedia.org/wiki/Persian_language#Persian_language_name_in_English