### PR TITLE
Fix a few alerts from LGTM.com

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,11 @@
+path_classifiers:
+  lobrary:
+    - static/css/jquery.tagsinput.css
+    - static/js/buzz.js
+    - static/js/d3.min.js
+    - static/js/howler.min.js
+    - static/js/jquery.nouislider.min.js
+    - static/js/jquery.tagsinput.js
+    - static/js/jquery-1.9.1.min.js
+    - static/js/reconnecting-websocket.min.js
+    - static/js/seedrandom.js

--- a/static/index.html
+++ b/static/index.html
@@ -264,7 +264,7 @@
         testuser()
         */
 
-        for (lang in langs) {
+        for (var lang in langs) {
             if (langs.hasOwnProperty(lang)) {
                 if (lang == 'wikidata') {
                     $('#lang-boxes').append('<p><input type="checkbox" name="' + langs[lang][0] + '" id="' + lang + '-enable"/><label for="' + lang + '-enable">' + langs[lang][0] + ' <span class="conStatus" id="' + lang + '-status"></span></label></p>')
@@ -286,11 +286,11 @@
             enabled_langs.push(DEFAULT_LANG)
         }
         for (var i = 0; i < enabled_langs.length + 1; i ++) {
-            var lang = enabled_langs[i];
-            $('#' + lang + '-enable').prop('checked', true);
-            if (SOCKETS[lang] && (!SOCKETS[lang].connection ||
-                                  SOCKETS[lang].connection.readyState == 3)) {
-                SOCKETS[lang].connect();
+            var enabled_lang = enabled_langs[i];
+            $('#' + enabled_lang + '-enable').prop('checked', true);
+            if (SOCKETS[enabled_lang] && (!SOCKETS[enabled_lang].connection ||
+                                  SOCKETS[enabled_lang].connection.readyState == 3)) {
+                SOCKETS[enabled_lang].connect();
             }
         }
       $('#filter').tagsInput({

--- a/static/index.html
+++ b/static/index.html
@@ -133,7 +133,7 @@
         d = document,
         e = d.documentElement,
         g = d.getElementsByTagName('#area svg')[0],
-        width = w.innerWidth || e.clientWidth || g.clientWidth;
+        width = w.innerWidth || e.clientWidth || g.clientWidth,
         height = (w.innerHeight  - $('#header').height())|| (e.clientHeight - $('#header').height()) || (g.clientHeight - $('#header').height());
 
     var celesta = [],

--- a/static/index.html
+++ b/static/index.html
@@ -276,7 +276,7 @@
             }
         }
 
-        enabled_langs = return_lang_settings();
+        var enabled_langs = return_lang_settings();
 
         if (!enabled_langs.length) {
             enabled_langs.push(DEFAULT_LANG)

--- a/static/index.html
+++ b/static/index.html
@@ -226,11 +226,7 @@
 
         // load celesta and clav sounds
         for (var i = 1; i <= 24; i++) {
-            if (i > 9) {
-                fn = 'c0' + i;
-            } else {
-                fn = 'c00' + i;
-            }
+            var fn = (i > 9) ? 'c0' + i : 'c00' + i;
             celesta.push(new Howl({
                 urls : ['sounds/celesta/' + fn + '.ogg',
                         'sounds/celesta/' + fn + '.mp3'],

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -10,7 +10,7 @@ function wp_action(data, svg_area, silent) {
     }
     var now = new Date();
     edit_times.push(now);
-    to_save = [];
+    var to_save = [];
     if (edit_times.length > 1) {
         for (var i = 0; i < edit_times.length + 1; i ++) {
             var i_time = edit_times[i];

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -47,7 +47,7 @@ function wp_action(data, svg_area, silent) {
     var abs_size = Math.abs(size);
     size = Math.max(Math.sqrt(abs_size) * scale_factor, 3);
 
-    Math.seedrandom(data.page_title)
+    Math.seedrandom(data.page_title);
     var x = Math.random() * (width - size) + size;
     var y = Math.random() * (height - size) + size;
     if (!silent) {
@@ -67,7 +67,7 @@ function wp_action(data, svg_area, silent) {
     var circle_group = svg_area.append('g')
         .attr('transform', 'translate(' + x + ', ' + y + ')')
         .attr('fill', edit_color)
-        .style('opacity', starting_opacity)
+        .style('opacity', starting_opacity);
 
     var ring = circle_group.append('circle')
          .attr({r: size + 20,
@@ -172,7 +172,7 @@ wikipediaSocket.init = function(ws_url, lid, svg_area) {
                         return i.toLowerCase();
                     })).length > 0)) {
                         if (TAG_FILTERS.length > 0) {
-                            console.log('Filtering for: ' + TAG_FILTERS)
+                            console.log('Filtering for: ' + TAG_FILTERS);
                         }
                         if (data.summary &&
                             (data.summary.toLowerCase().indexOf('revert') > -1 ||
@@ -450,7 +450,7 @@ function update_tag_warning(svg_area) {
             tag_area.remove();
             tag_area = {}, tag_text = false;
         }
-        return
+        return;
     }
     if (!tag_text) {
         tag_area = svg_area.append('g');
@@ -488,7 +488,7 @@ var insert_comma = function(s) {
     } else {
         return s;
     }
-}
+};
 
 function getChromeVersion () {
     // From https://stackoverflow.com/questions/4900436/how-to-detect-the-installed-chrome-version

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -43,7 +43,6 @@ function wp_action(data, svg_area, silent) {
         type = 'user';
     }
 
-    var circle_id = 'd' + ((Math.random() * 100000) | 0);
     var abs_size = Math.abs(size);
     size = Math.max(Math.sqrt(abs_size) * scale_factor, 3);
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -135,7 +135,6 @@ function wikipediaSocket() {
 wikipediaSocket.init = function(ws_url, lid, svg_area) {
     this.connect = function() {
         $('#' + lid + '-status').html('(connecting...)');
-        var loading = true;
         // Terminate previous connection, if any
         if (this.connection)
           this.connection.close();

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -341,7 +341,7 @@ var return_hash_settings = function() {
 
 var return_lang_settings = function() {
     var enabled_hash = return_hash_settings();
-    enabled_langs = [];
+    var enabled_langs = [];
     for (var i = 0; i < enabled_hash.length +1; i ++) {
         var setting = enabled_hash[i];
         if (langs[setting]) {


### PR DESCRIPTION
This PR fixes all the alerts from [LGTM.com](https://lgtm.com/projects/g/hatnote/listen-to-wikipedia/alerts/?mode=tree) that I thought were correct and useful. There's nothing massively critical but they are still results where it's nice to fix them and make the code a little cleaner. The rest of the results that I haven't addressed are either results in libraries or deliberate actions so I didn't want to change anything.

Let me know if any of the results don't make sense or if you think something is wrong. There are links on LGTM to the [alert help](https://lgtm.com/rules/7860083/) which describes what the result means and why it is good to address it. For full disclosure I do work at the company that makes LGTM.com and I'm happy to answer any questions.

I've also added a `.lgtm.yml` file to the repository which is what we use to allow you to customize the results. In this case it marks a few files as library code so you won't see the alerts in them. If you don't want this file then I'm happy to remove it from the PR, but hopefully it's not too intrusive.

If you wanted then you could even enable [automatic code review integration](https://lgtm.com/projects/g/hatnote/listen-to-wikipedia/ci/) and then LGTM will analyze pull requests that get made and make sure that no problems creep back in. Entirely up to you.